### PR TITLE
Add setting classes using @umm/setting_core

### DIFF
--- a/Assets/AssemblyDefinition.asmdef
+++ b/Assets/AssemblyDefinition.asmdef
@@ -1,6 +1,8 @@
 {
   "name": "umm@context_management",
-  "references": [],
+  "references": [
+    "umm@setting_core"
+  ],
   "optionalUnityReferences": [],
   "includePlatforms": [],
   "excludePlatforms": [],

--- a/Assets/Scripts/UnityModule/Settings.meta
+++ b/Assets/Scripts/UnityModule/Settings.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 736be40f91df47afa4a2f5d6df7accf7
+timeCreated: 1529286112

--- a/Assets/Scripts/UnityModule/Settings/ProjectContextListSetting.cs
+++ b/Assets/Scripts/UnityModule/Settings/ProjectContextListSetting.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityModule.ContextManagement;
+
+namespace UnityModule.Settings
+{
+    public class ProjectContextListSetting : Setting<ProjectContextListSetting>
+    {
+        [SerializeField] private List<ProjectContextSetting> list = new List<ProjectContextSetting>();
+
+        private IEnumerable<ProjectContextSetting> List => list;
+
+        private void OnEnable()
+        {
+            ContextManager.CurrentProject = List?.FirstOrDefault();
+        }
+
+        public void Add(ProjectContextSetting projectContextSetting)
+        {
+            list.Add(projectContextSetting);
+        }
+
+#if UNITY_EDITOR
+        public static void CreateSettingAsset()
+        {
+            SettingContainer.Instance.Add(CreateAsset(true));
+        }
+#endif
+    }
+}

--- a/Assets/Scripts/UnityModule/Settings/ProjectContextListSetting.cs.meta
+++ b/Assets/Scripts/UnityModule/Settings/ProjectContextListSetting.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 575f9809ee204bd68fd70b8844930400
+timeCreated: 1529286221

--- a/Assets/Scripts/UnityModule/Settings/ProjectContextSetting.cs
+++ b/Assets/Scripts/UnityModule/Settings/ProjectContextSetting.cs
@@ -1,0 +1,36 @@
+﻿using UnityEngine;
+using UnityModule.ContextManagement;
+
+namespace UnityModule.Settings
+{
+    public class ProjectContextSetting : Setting<ProjectContextSetting>, IProjectContext
+    {
+        [SerializeField] private string projectName;
+        [SerializeField] private string sceneNamePrefix;
+        [SerializeField] private string namespacePrefix;
+
+        public string Name => projectName;
+
+        public string SceneNamePrefix => sceneNamePrefix;
+
+        public string NamespacePrefix => namespacePrefix;
+
+        public string CreateSceneName<TEnum>(TEnum sceneName) where TEnum : struct
+        {
+            return $"{SceneNamePrefix.TrimEnd('_')}_{sceneName.ToString()}";
+        }
+
+#if UNITY_EDITOR
+        [UnityEditor.MenuItem("Assets/Create/Settings/ProjectContext")]
+        public static void CreateSettingAsset()
+        {
+            if (!SettingContainer.Instance.Exists<ProjectContextListSetting>())
+            {
+                ProjectContextListSetting.CreateSettingAsset();
+            }
+            SettingContainer.Instance.Get<ProjectContextListSetting>().Add(CreateAsset());
+            UnityEditor.AssetDatabase.SaveAssets();
+        }
+#endif
+    }
+}

--- a/Assets/Scripts/UnityModule/Settings/ProjectContextSetting.cs.meta
+++ b/Assets/Scripts/UnityModule/Settings/ProjectContextSetting.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 42ee970c5e60488486dab24d7609a1ee
+timeCreated: 1529286113


### PR DESCRIPTION
* [`@umm/setting_core`](https://github.com/umm-projects/setting_core) を用いた ProjectContext 管理クラスを実装
* メニューから Assets > Create > Settings > ProjectContext を選択すると、自動的に `ProjectContextSetting` の ScriptableObject と、それらを束ねる `ProjectContextListSetting` の ScriptableObject が生成されます。
    * 更に `setting_core` の機能である `SettingContainer` に対して自動的に `ProjectContextSettingListSetting` を登録します。
* ランタイムでは `SettingContainer.Instance.Get<ProjectContextListSetting>().List.FirstOrDefault()` などを通じて `ProjectContextSetting` のインスタンスを取り出して使います。